### PR TITLE
Fix redundant INI entries

### DIFF
--- a/client/both_weapon_changes.xml
+++ b/client/both_weapon_changes.xml
@@ -6,7 +6,7 @@
 
 ## Nomad mine effect*** Nosfi wollte es so ;P
 
-<data file="data\fx\effects.ini" method="sectionappend">
+<data file="data\fx\effects.ini" method="sectionreplace">
 <section>
 [Effect]
 nickname = rtc_nomadtorpedo_impact
@@ -39,7 +39,7 @@ impulse = 0
 </source>
 </data>
 
-<data file="data\equipment\weapon_equip.ini" method="sectionappend">
+<data file="data\equipment\weapon_equip.ini" method="sectionreplace">
 <section>
 [Munition]
 nickname = nomad_torpedo01_rtc_ammo
@@ -86,7 +86,7 @@ volume = 0.000000
 </data>
 
 
-<data file="data\equipment\weapon_equip.ini" method="sectionappend">
+<data file="data\equipment\weapon_equip.ini" method="sectionreplace">
 <section>
 [Gun]
 nickname = nomad_torpedo01_rtc
@@ -164,7 +164,7 @@ combinable = true
 </source>
 </data>
 
-<data file="data\equipment\weapon_good.ini" method="sectionappend">
+<data file="data\equipment\weapon_good.ini" method="sectionreplace">
 <section>
 [Good]
 nickname = nomad_torpedo01_rtc

--- a/server/both_weapon_changes.xml
+++ b/server/both_weapon_changes.xml
@@ -6,7 +6,7 @@
 
 ## Nomad mine effect*** Nosfi wollte es so ;P
 
-<data file="data\fx\effects.ini" method="sectionappend">
+<data file="data\fx\effects.ini" method="sectionreplace">
 <section>
 [Effect]
 nickname = rtc_nomadtorpedo_impact
@@ -39,7 +39,7 @@ impulse = 0
 </source>
 </data>
 
-<data file="data\equipment\weapon_equip.ini" method="sectionappend">
+<data file="data\equipment\weapon_equip.ini" method="sectionreplace">
 <section>
 [Munition]
 nickname = nomad_torpedo01_rtc_ammo
@@ -86,7 +86,7 @@ volume = 0.000000
 </data>
 
 
-<data file="data\equipment\weapon_equip.ini" method="sectionappend">
+<data file="data\equipment\weapon_equip.ini" method="sectionreplace">
 <section>
 [Gun]
 nickname = nomad_torpedo01_rtc
@@ -164,7 +164,7 @@ combinable = true
 </source>
 </data>
 
-<data file="data\equipment\weapon_good.ini" method="sectionappend">
+<data file="data\equipment\weapon_good.ini" method="sectionreplace">
 <section>
 [Good]
 nickname = nomad_torpedo01_rtc


### PR DESCRIPTION
Sectionappend doesn't execute "dest" command in script.xml.
As a result, almost every entry for this particular weapon exists two times in several INIs.
It's a miracle that the server didn't crash